### PR TITLE
Resolve neverallow in retrofit devices

### DIFF
--- a/private/remount.te
+++ b/private/remount.te
@@ -1,4 +1,3 @@
-type remount, domain, coredomain;
 type remount_exec, system_file_type, exec_type, file_type;
 
 userdebug_or_eng(`

--- a/public/domain.te
+++ b/public/domain.te
@@ -617,6 +617,7 @@ neverallow {
   userdebug_or_eng(`-fsck')
   userdebug_or_eng(`-init')
   -recovery
+  userdebug_or_eng(`-remount')
   -update_engine
 } system_block_device:blk_file { write append };
 

--- a/public/remount.te
+++ b/public/remount.te
@@ -1,0 +1,1 @@
+type remount, domain, coredomain;


### PR DESCRIPTION
Commit Ia78d4b0ea942a139c8a4070dc63a0eed218e3e18 added the following rule for debuggable builds:
    allow remount super_block_device_type:blk_file rw_file_perms;

That causes a neverallow on retrofit devices that define this:
    typeattribute system_block_device super_block_device_type;

Test: m; observe no neverallow in userdebug build
Change-Id: I7cfe160542b2e9b290bc1d6470c6286b5ca21e1f